### PR TITLE
Refactored Merge-HashTablesAndObjects to support single element arrays.

### DIFF
--- a/Functions/Internal.Tests.ps1
+++ b/Functions/Internal.Tests.ps1
@@ -1,0 +1,115 @@
+$VerbosePreference = "continue"
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+
+Function Get-NestedPSObject() {
+    [PSCustomObject]$nested_object = @{
+        "a_element1" = @{
+            "ab_element1" = @{
+                "abc_element1" = "d_leaf"
+            }
+        }
+    }
+
+    Return $nested_object
+}
+
+Function Get-NestedHashTable() {
+    $nested_object = @{
+        "h_a_element1" = @{
+            "h_ab_element1" = @{
+                "h_abc_element1" = "h_abcd_leaf"
+            }
+        }
+    }
+
+    Return $nested_object
+}
+
+Function Get-NestedPSObjectWithArrays() {
+    $a_element1 = New-Object -TypeName PSObject
+    $ab_element1 = New-Object -TypeName PSObject
+    
+    $ab_element2 = @(
+        "abc2_leaf1",
+        "abc2_leaf2",
+        "abc2_leaf3"
+    )
+
+    $ab_element1 | Add-Member -MemberType NoteProperty -Name "abc_element1" -Value "abc1_leaf"
+
+    $a_element1 | Add-Member -MemberType NoteProperty -Name "ab_element1" -Value $ab_element1
+    $a_element1 | Add-Member -MemberType NoteProperty -Name "ab_element2" -Value $ab_element2
+
+    $nested_object = New-Object -TypeName PSObject
+    $nested_object | Add-Member -MemberType NoteProperty -Name "a_element1" -Value $a_element1
+
+    Return $nested_object
+}
+
+Function Get-NestedPSObjectWithUnaryArrays() {
+    $a_element1 = New-Object -TypeName PSObject
+    $ab_element1 = New-Object -TypeName PSObject
+    $ab_element2 = New-Object -TypeName PSObject
+    
+    $ab_element2 = @(
+        "abc2_leaf1"
+    )
+
+    $ab_element1 | Add-Member -MemberType NoteProperty -Name "abc_element1" -Value "abc1_leaf"
+
+    $a_element1 | Add-Member -MemberType NoteProperty -Name "ab_element1" -Value $ab_element1
+    $a_element1 | Add-Member -MemberType NoteProperty -Name "ab_element2" -Value $ab_element2
+
+    $nested_object = New-Object -TypeName PSObject
+    $nested_object | Add-Member -MemberType NoteProperty -Name "a_element1" -Value $a_element1
+
+    Return $nested_object
+}
+
+Function Write-PSLog {}
+
+Describe "Merge-HashTablesAndObjects" {
+
+    Context "when given a single nested PSObject with unary arrays" {
+
+        It "should convert to json correctly" {
+            Mock Write-PSLog { }
+            
+            $obj_set = Get-NestedPSObjectWithUnaryArrays
+            Write-Verbose "Current context obj set:"
+            Write-Verbose ($obj_set | Out-String)
+
+            $merge_result = Merge-HashtablesAndObjects -InputObjects $obj_set
+            Write-Verbose $merge_result
+
+            $result = ConvertTo-Json -InputObject $merge_result -Depth 10 -Compress
+            $result | Should Be '{"a_element1":{"ab_element1":{"abc_element1":"abc1_leaf"},"ab_element2":["abc2_leaf1"]}}'
+
+        }
+    }
+
+    Context "When given a nested PSObject with unary arrays and a nested hashtable" {
+
+        It "should convert to json correctly" {
+            Mock Write-PSLog { }
+
+            $obj_set1 = Get-NestedPSObjectWithUnaryArrays
+            Write-Verbose "Current context obj_set1:"
+            Write-Verbose ($obj_set1 | Out-String)
+
+            $obj_set2 = Get-NestedHashTable
+            Write-Verbose "Current context obj_set2:"
+            Write-Verbose ($obj_set2 | Out-String)
+
+            $merge_result = Merge-HashtablesAndObjects -InputObjects $obj_set1,$obj_set2
+            # Write-Verbose $merge_result
+
+            $result = ConvertTo-Json -InputObject $merge_result -Depth 10 -Compress
+            # Write-Verbose $result
+            $result | Should Be '{"a_element1":{"ab_element1":{"abc_element1":"abc1_leaf"},"ab_element2":["abc2_leaf1"]},"h_a_element1":{"h_ab_element1":{"h_abc_element1":"h_abcd_leaf"}}}'
+        }
+    }
+}

--- a/Functions/Start-SensuChecks.ps1
+++ b/Functions/Start-SensuChecks.ps1
@@ -128,9 +128,11 @@ function Start-SensuChecks
                             Write-PSLog @loggingDefaults -Method DEBUG -Message "Check Result Returned. Merging Data From Config File ::: Check Name: $($check.name)"
 
                             # Merge all the data about the job and return it
-                            $finalCheckResult = Merge-HashtablesAndObjects -InputObjects $j.($check.name),$ChecksToValidate,$check -ExcludeProperties 'checks' | ConvertTo-Json
+                            $finalCheckResultPso = $null
+                            $finalCheckResultPso = Merge-HashtablesAndObjects -InputObjects $j.($check.name),$ChecksToValidate,$check -ExcludeProperties 'checks'
+                            $finalCheckResult = $null
+                            $finalCheckResult = ConvertTo-Json ($finalCheckResultPso) -Depth 10 -Compress
                             Write-PSLog @loggingDefaults -Method DEBUG -Message "Check Result ::: Check Name: $($check.name) Result: $finalCheckResult"
-
                             if ($TestMode)
                             {
                                 Write-Output $finalCheckResult


### PR DESCRIPTION
This PR adds support for deep merging of hash tables and PSObjects. It also correctly merges single-element arrays. This allows for structures such as the following, which are required for some plugins.

`
"slack": {
  "channels": ["#my_channel"]
}
`

I've included a couple tests for the rewritten function.